### PR TITLE
Use $EDITOR instead of vim

### DIFF
--- a/goin.go
+++ b/goin.go
@@ -54,7 +54,12 @@ func ReadBytesFromFile(tempBufferFileName string) ([]byte, error) {
 }
 
 func openEditor(fileName string) error {
-	cmd := exec.Command("vim", fileName)
+	ed := os.Getenv("EDITOR")
+	if ed == "" {
+		ed = "vim"
+	}
+
+	cmd := exec.Command(ed, fileName)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	return cmd.Run()


### PR DESCRIPTION
[joe](https://joe-editor.sourceforge.io/) is clearly the editor of choice for most hardcore engineers these days! or ofcourse maybe even `ed` ... but let's not even get into the [Church of Emacs](https://en.wikipedia.org/wiki/Editor_war#Humor) references...

In all seriousness, editors are not just a choice, they are a way of life! This simply gives the people what they already know they want by using the value specified in the users `EDITOR` environment variable. We still default to `vim` if it's not set, because we all know that it is the superior editor.